### PR TITLE
BASW-640: Fix regression on the settings form page

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.extra.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.extra.tpl
@@ -2,16 +2,14 @@
   {$error_message.message}
 {/if}
 {if $upcomingWebinars}
-<div class="crm-accordion-wrapper crm-accordion-open">
-  <div class="crm-accordion-header">
-      {ts}Webinar Key Settings{/ts}
-  </div>
-  <div class="crm-accordion-body">
-    <div id="webinarTableWarpper">
-      <h4><strong>Click any row below to populate Webinar Key.</strong></h4>
-
+<div id="webinarTableWrapper">
+  <div class="crm-accordion-wrapper crm-accordion-open">
+    <div class="crm-accordion-header">
+        {ts}Webinar Key Settings{/ts}
+    </div>
+    <div class="crm-accordion-body">
+      <div class="help">Click any row below to populate Webinar Key.</div>
       <table id="webinar_settings" cellspacing="0" width="100%" >
-
         <thead>
           <tr>
             <th>Description</th>
@@ -21,7 +19,6 @@
             <th>End Time</th>
           </tr>
         </thead>
-
         <tbody>
           {foreach from=$upcomingWebinars item=webinar}
           {assign var=times value=$webinar.times}
@@ -38,27 +35,31 @@
     </div>
   </div>
 </div>
-
 {literal}
 <script>
-cj(document).ready(function() {
-  var webinar_settings = cj('#webinarTableWarpper').html();
-  if (cj('#webinarTableWarpper').length == 0) {
-    cj("input[data-crm-custom='Webinar_Event:Webinar_id']").parent().parent().parent().parent().after(webinar_settings);
-  };
+  (function(cj){
+    var webinarSettingsWrapperSelector = '#webinarTableWrapper';
+    var webinarSettingsTableSelector = '#webinar_settings';
+    var webinarKeyFieldSelector = 'input[data-crm-custom="Webinar_Event:Webinar_id"]';
+    var formContainerSelector = '#crm-main-content-wrapper #EventInfo';
 
-  cj(document).tooltip();
+    cj(document).ready(function() {
+      cj(document).tooltip();
 
-  cj('#webinar_settings tbody').on('click', 'tr', function (){
-    var name = cj('td', this).eq(2).text();
-    cj("input[data-crm-custom='Webinar_Event:Webinar_id']").val(name);
-  });
+      cj(webinarSettingsTableSelector).find('tbody').on('click', 'tr', function (){
+        var name = cj('td', this).eq(2).text();
 
-  cj('#webinar_settings').dataTable();
-  // if(cj(window.ids).length==0){
-  //   cj('#webinarTableWarpper').hide();
-  // }
-});
+        cj(webinarKeyFieldSelector).val(name);
+      });
+
+      cj(webinarSettingsTableSelector).dataTable();
+
+      // Attach this wrapper just before action buttons.
+      cj(formContainerSelector)
+        .find('.crm-submit-buttons:last-of-type')
+        .before(cj(webinarSettingsWrapperSelector));
+    });
+  })(cj);
 </script>
 {/literal}
 {/if}

--- a/templates/CRM/Gotowebinar/Form/Setting.tpl
+++ b/templates/CRM/Gotowebinar/Form/Setting.tpl
@@ -22,81 +22,86 @@
       <br/>
       <br/>
       {/if}
-
       {if $responseKey}
-        <div class="crm-webinar-information-api-key-block alert alert-info">
+        <div class="crm-webinar-information-api-key-block help">
             <strong>Info:</strong> Your account is connected.&nbsp;Here are your Upcoming Webinars
         </div>
       {/if}
-      <table class="dataTable">
       {if $initial}
-        <tr class="crm-webinar-setting-api-key-block">
-          <td class="label">{$form.api_key.label}</td>
-          <td>{$form.api_key.html}<br/>
-            <span class="description">{ts}The Consumer Key from your GoToWebinar App{/ts}
-            </span>
-          </td>
-        </tr>
-        <tr class="crm-webinar-setting-client-secret-block">
-          <td class="label">{$form.client_secret.label}</td>
-          <td>{$form.client_secret.html}<br/>
-            <span class="description">{ts}The Consumer Secret from your GoToWebinar App{/ts}
-            </span>
-          </td>
-        </tr>
-        <tr class="crm-webinar-setting-api-key-email">
-          <td class="label">{$form.email_address.label}</td>
-          <td>{$form.email_address.html}<br/>
-            <span class="description">{ts}Username to connect Webinar account{/ts}
-            </span>
-          </td>
-        </tr>
-        <tr class="crm-webinar-setting-api-key-password">
-          <td class="label">{$form.password.label}</td>
-          <td>{$form.password.html}<br/>
-            <span class="description">{ts}Password to connect Webinar account{/ts}
-            </span>
-          </td>
-        </tr>
-        {/if}
-        {if $responseKey}
-          <thead >
-            <tr>
-              <th>{ts}Description{/ts}</th>
-              <th>{ts}Subject{/ts}</th>
-              <th>{ts}Webinar Key{/ts}</th>
-              <th>{ts}Start Time{/ts}</th>
-              <th>{ts}End Time{/ts}</th>
-           </tr>
-           <tbody>
-              {foreach from=$upcomingWebinars item=webinar}
-                <tr>
-                  <td>{$webinar.description}</td>
-                  <td>
-                    {$webinar.subject}
-                    <p style="color: red;">{$webinar.warning}</p>
-                  </td>
-                  <td>{$webinar.webinarKey}</td>
-                  {assign var=times value=$webinar.times}
-                  <td>{$times[0].startTime|crmDate}</td>
-                  <td>{$times[0].endTime|crmDate}</td>
-                </tr>
-              {/foreach}
-            </tbody>
-        {/if}
-        {if $clienterror}
-            <tr class="crm-webinar-information-erro-api-key-block">
-            <td class="label" style="color:red">{ts} Info:{/ts}</td>
-            <td class="label" style="color:red">{ts}{$clienterror.int_err_code}{/ts}&nbsp;&nbsp;&nbsp;&nbsp;{ts}{$clienterror.msg}{/ts}</td>
-            </tr>
-        {/if}
-        {if $error}
-            <tr class="crm-webinar-information-erro-api-key-block">
-            <td class="label" style="color:red">{ts} Info:{/ts}</td>
-            <td class="label" style="color:red">{ts}{$error.int_err_code}{/ts}&nbsp;&nbsp;&nbsp;&nbsp;{ts}{$error.msg}{/ts}</td>
-            </tr>
-        {/if}
-      </table>
+        <table class="form-layout-compressed">
+          <tr class="crm-webinar-setting-api-key-block">
+            <td class="label">{$form.api_key.label}</td>
+            <td>{$form.api_key.html}<br/>
+              <span class="description">{ts}The Consumer Key from your GoToWebinar App{/ts}
+              </span>
+            </td>
+          </tr>
+          <tr class="crm-webinar-setting-client-secret-block">
+            <td class="label">{$form.client_secret.label}</td>
+            <td>{$form.client_secret.html}<br/>
+              <span class="description">{ts}The Consumer Secret from your GoToWebinar App{/ts}
+              </span>
+            </td>
+          </tr>
+          <tr class="crm-webinar-setting-api-key-email">
+            <td class="label">{$form.email_address.label}</td>
+            <td>{$form.email_address.html}<br/>
+              <span class="description">{ts}Username to connect Webinar account{/ts}
+              </span>
+            </td>
+          </tr>
+          <tr class="crm-webinar-setting-api-key-password">
+            <td class="label">{$form.password.label}</td>
+            <td>{$form.password.html}<br/>
+              <span class="description">{ts}Password to connect Webinar account{/ts}
+              </span>
+            </td>
+          </tr>
+        </table>
+      {/if}
+      {if $responseKey}
+      <table class="dataTable">
+        <thead >
+          <tr>
+            <th>{ts}Description{/ts}</th>
+            <th>{ts}Subject{/ts}</th>
+            <th>{ts}Webinar Key{/ts}</th>
+            <th>{ts}Start Time{/ts}</th>
+            <th>{ts}End Time{/ts}</th>
+         </tr>
+         <tbody>
+            {foreach from=$upcomingWebinars item=webinar}
+              <tr>
+                <td>{$webinar.description}</td>
+                <td>
+                  {$webinar.subject}
+                  <p style="color: red;">{$webinar.warning}</p>
+                </td>
+                <td>{$webinar.webinarKey}</td>
+                {assign var=times value=$webinar.times}
+                <td>{$times[0].startTime|crmDate}</td>
+                <td>{$times[0].endTime|crmDate}</td>
+              </tr>
+            {/foreach}
+          </tbody>
+        </table>
+      {/if}
+      {if $clienterror}
+        <table class="form-layout-compressed">
+          <tr class="crm-webinar-information-erro-api-key-block">
+          <td class="label" style="color:red">{ts} Info:{/ts}</td>
+          <td class="label" style="color:red">{ts}{$clienterror.int_err_code}{/ts}&nbsp;&nbsp;&nbsp;&nbsp;{ts}{$clienterror.msg}{/ts}</td>
+          </tr>
+        </table>
+      {/if}
+      {if $error}
+        <table class="form-layout-compressed">
+          <tr class="crm-webinar-information-erro-api-key-block">
+          <td class="label" style="color:red">{ts} Info:{/ts}</td>
+          <td class="label" style="color:red">{ts}{$error.int_err_code}{/ts}&nbsp;&nbsp;&nbsp;&nbsp;{ts}{$error.msg}{/ts}</td>
+          </tr>
+        </table>
+      {/if}
     </div>
     <div class="crm-submit-buttons">
       {include file="CRM/common/formButtons.tpl"}


### PR DESCRIPTION
## Overview
This PR fixes the regression introduced on https://github.com/veda-consulting/uk.co.vedaconsulting.gotowebinar/pull/43 and fix the styling of the info box on the listing page

### Before - shoreditch - form
<img width="1649" alt="Screenshot 2020-05-28 at 4 13 41 PM" src="https://user-images.githubusercontent.com/3340537/83133017-d7738c00-a0ff-11ea-965c-f4ca75e092f9.png">

### After - shoreditch - form
<img width="1649" alt="Screenshot 2020-05-28 at 4 08 33 PM" src="https://user-images.githubusercontent.com/3340537/83133044-e22e2100-a0ff-11ea-8f71-a88a2ddd0b4c.png">

### Before - civicrm - form
<img width="1646" alt="Screenshot 2020-05-28 at 4 14 26 PM" src="https://user-images.githubusercontent.com/3340537/83133072-f07c3d00-a0ff-11ea-8433-74228650e571.png">

### After - civicrm - form
<img width="1649" alt="Screenshot 2020-05-28 at 4 14 51 PM" src="https://user-images.githubusercontent.com/3340537/83133095-f7a34b00-a0ff-11ea-9943-90daedd99b35.png">

### Before - shoreditch - listing
<img width="1678" alt="Screenshot 2020-05-28 at 4 12 09 PM" src="https://user-images.githubusercontent.com/3340537/83133129-0427a380-a100-11ea-9d4d-97bc42b62f9e.png">

### After - shoreditch - listing
<img width="1663" alt="Screenshot 2020-05-28 at 4 11 38 PM" src="https://user-images.githubusercontent.com/3340537/83133170-13a6ec80-a100-11ea-8696-7dd9caac3fa4.png">

### Before - civicrm - listing
<img width="1661" alt="Screenshot 2020-05-28 at 4 12 54 PM" src="https://user-images.githubusercontent.com/3340537/83133188-1bff2780-a100-11ea-9fd7-bb63877fe50b.png">

### After - civicrm - listing
<img width="1675" alt="Screenshot 2020-05-28 at 4 13 17 PM" src="https://user-images.githubusercontent.com/3340537/83133218-28838000-a100-11ea-9a17-6f591033ef49.png">

## Technical Details
`dataTable` class was changed from `form-layout-compressed` but since there was a single `<table>` container, `dataTable` class was added for the settings form too. This PR fixes this by providing separate `<table>` containers for these container table elements
This also changes the info box class from `alert` to `info`.

## Update
This PR also solves the issue with the webinar key table placement while creating a new event.
### Before - Core civi
<img width="1678" alt="Screenshot 2020-06-01 at 10 28 49 AM" src="https://user-images.githubusercontent.com/3340537/83386400-a6999c80-a408-11ea-98cf-c2ca42edb7c1.png">

### After - Core civi
<img width="1118" alt="Screenshot 2020-06-01 at 1 02 59 PM" src="https://user-images.githubusercontent.com/3340537/83386413-ac8f7d80-a408-11ea-84f6-b8de25986198.png">

### Before - Shoreditch
<img width="1668" alt="Screenshot 2020-06-01 at 10 27 45 AM" src="https://user-images.githubusercontent.com/3340537/83386421-b1ecc800-a408-11ea-9df8-a07c3aee9ea6.png">

### After - Shoreditch
<img width="1667" alt="Screenshot 2020-06-01 at 1 02 05 PM" src="https://user-images.githubusercontent.com/3340537/83386439-b6b17c00-a408-11ea-89ae-455737e070dd.png">

### Technical Details
The problem was with the JS which was not correctly written to handle the placement of the table. 
Now, the JS is tweaked to place the table just before the action buttons in the last. See `EventInfo.extra.tpl` js code.
Also, the accordion wrapper classes and HTML was moved inside `webinarTableWrapper`div (this name typo was also fixed in this PR)
